### PR TITLE
RiscOS compatible network setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,15 @@
 File Server Emulator 2
 
 Improved version which uses L3V126 file server ($.FS).
+
+## Advanced networking
+
+By default the server will listen as station 254 on `0.0.0.0:10254`
+
+The station ID can be changed with the option `-s` flag.  eg `-s 100` will set the server to station 100 listening on `0.0.0.0:10100`
+
+This works well for BeebEm but will not work with RiscOS nor with [PiEconetBridge](https://github.com/cr12925/PiEconetBridge) in RiscOS compatibility mode.
+
+With RiscOS the port is always 32768, and the station ID is based on the last octet of the IP address.  So if your IP address is 192.168.1.100 then you would be station 100.
+
+This can be set up with the `-a` option.  You should set the `-s` station ID as well.  eg  `-a 192.168.1.100 -s 100`.  Now it will listen on `192.168.1.100:32768`

--- a/aun.c
+++ b/aun.c
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <arpa/inet.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
 #include <sys/time.h>//timeval
 #include <unistd.h>
 #include <fcntl.h>
@@ -30,13 +31,14 @@ static struct sockaddr_in si_me, si_other;
 static int mysock, slen = sizeof(si_other), rxlen;
 static uint8_t *rxbuf = NULL;
 static uint16_t mystn, otherstn;
+static uint8_t riscos_mode = 0;
 
 static void die(char *s) {
 	perror(s);
 	exit(1);
 }
 
-static void _opensock() {
+static void _opensock(in_addr_t listen_addr) {
 	//create a UDP socket
 	if ((mysock=socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) == -1)
 		die("socket");
@@ -45,8 +47,14 @@ static void _opensock() {
 	memset((char *) &si_me, 0, sizeof(si_me));
 	
 	si_me.sin_family = AF_INET;
-	si_me.sin_port = htons(AUN_PORT_BASE + mystn);
-	si_me.sin_addr.s_addr = htonl(INADDR_ANY);
+	if (listen_addr == INADDR_ANY)
+		si_me.sin_port = htons(AUN_PORT_BASE + mystn);
+	else
+	{
+		si_me.sin_port = htons(32768);
+		riscos_mode = 1;
+	}
+	si_me.sin_addr.s_addr = listen_addr;
 	
 	//bind socket to port
 	if (bind(mysock, (struct sockaddr*) &si_me, sizeof(si_me)) == -1)
@@ -173,7 +181,10 @@ int aun_receiver(int ackwait) {
 			die("recvfrom()");
 	} else if (rxlen >= AUN_HDR_SIZE) {
 		//printf("Received packet from %s:%d length=%d\n", inet_ntoa(si_other.sin_addr), ntohs(si_other.sin_port), rxlen);
-		otherstn = ntohs(si_other.sin_port) - AUN_PORT_BASE;
+		if (riscos_mode && ntohs(si_other.sin_port) == 32768)
+			otherstn = ntohl(si_other.sin_addr.s_addr) & 255;
+		else
+			otherstn = ntohs(si_other.sin_port) - AUN_PORT_BASE;
 		//printf("stn=%d\n", otherstn);
 		if (otherstn < AUN_MAX_STATIONS) {
 			if (otherstn == mystn) 
@@ -245,12 +256,12 @@ int aun_transmitter(int retry) {
 }
 
 
-int aun_open(uint16_t stn) {
+int aun_open(uint16_t stn, in_addr_t listen_addr) {
 	//printf("aun_open stn=%d\n", stn);
 
 	mystn = stn;	// remember my station number
 	ebuf_open(AUN_MAX_BUFFERS);
-	_opensock();
+	_opensock(listen_addr);
 }
 
 int aun_close(void) {

--- a/aun.h
+++ b/aun.h
@@ -20,7 +20,9 @@
 
 #define ECONET_MACHINEPEEK	8
 
-int aun_open(uint16_t stn);
+#include <netinet/in.h>
+
+int aun_open(uint16_t stn, in_addr_t listen_addr);
 int aun_close(void);
 int aun_receiver(int ackwait);
 int aun_transmitter(int retry);

--- a/ebuf.c
+++ b/ebuf.c
@@ -11,11 +11,11 @@
 
 static int ebuf_count;
 static struct ebuf_t *ebufs = NULL;
-static int listen = 0;
+static int elisten = 0;
 
 void ebuf_listen(int x) {
 	//printf("ebuf_listen X = %d\n", x);
-	listen = x;
+	elisten = x;
 }
  
 void ebuf_open(int max_buffers) {
@@ -86,13 +86,13 @@ struct ebuf_t *ebuf_x(int x) {//assume x is valid
 
 struct ebuf_t *ebuf_rxfind(uint16_t stn, int port) {
 	
-	if (listen) {
-		struct ebuf_t *p = &ebufs[listen];
+	if (elisten) {
+		struct ebuf_t *p = &ebufs[elisten];
 
 		if ((p->port == 0 || p->port == port) && (p->station == 0 || p->station == stn))
 		{
-			//printf("FOUND listen=%d block=%d\n", listen, p->index);
-			listen = 0;
+			//printf("FOUND listen=%d block=%d\n", elisten, p->index);
+			elisten = 0;
 			return p;
 
 		}

--- a/main.c
+++ b/main.c
@@ -15,6 +15,8 @@
 #include <unistd.h>	//sleep()
 #include <time.h>
 #include <sys/socket.h> //for Cygwin
+#include <getopt.h>
+#include <arpa/inet.h>
 
 #include "aun.h"
 #include "ebuf.h"
@@ -36,16 +38,35 @@ int charsWaiting(int fd) {
 	return count;
 }
 
-int main(void) {
+int main(int argc, char *argv[]) {
 	char c, skey;
 	int ex = 0, rx = 0, tx = 0, loops = 0, rc, txcount = 0;
 	int rxto, flg, txretry;
 	time_t timeout1;
+	int my_stn=254;
+	in_addr_t listen_addr=INADDR_ANY;
+	struct in_addr inp;
+	int opt;
+
+	while ((opt = getopt(argc, argv, "s:a:")) != -1) {
+		switch (opt) {
+			case 's':
+				my_stn = atoi(optarg);
+				break;
+			case 'a':
+				opt=inet_pton(AF_INET,optarg,&inp);
+				listen_addr=inp.s_addr;
+				break;
+			default:
+				fprintf(stderr, "Usage: %s [-s stn_id] [-a ip.address.]\n",argv[0]);
+				exit(EXIT_FAILURE);
+		}
+	}
 
 	printf("File Server Emulator\n\n");
 
-	if (fsem_open("$.FS", 0x0400, 254, "scsi1.dat")) {
-		aun_open(254);
+	if (fsem_open("$.FS", 0x0400, my_stn, "scsi1.dat")) {
+		aun_open(my_stn,listen_addr);
 	
 		set_no_buffer();
 		do {


### PR DESCRIPTION
By default the server will listen as station 254 on `0.0.0.0:10254`

The station ID can be changed with the option `-s` flag.  eg `-s 100`
will set the server to station 100 listening on `0.0.0.0:10100`

This works well for BeebEm but will not work with RiscOS nor with
[PiEconetBridge](https://github.com/cr12925/PiEconetBridge) in RiscOS
compatibility mode.

With RiscOS the port is always 32768, and the station ID is based on the
last octet of the IP address.  So if your IP address is 192.168.1.100
then you would be station 100.

This can be set up with the `-a` option.  You should set the `-s` station
ID as well.  eg  `-a 192.168.1.100 -s 100`.  Now it will listen on
`192.168.1.100:32768`